### PR TITLE
CI: update ubuntu distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: xenial
 language: python
 python:
   - "3.5"


### PR DESCRIPTION
Atari-py doesn't work on ubuntu 14.04

OSError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.20' not found

I think we can run tests on Travis on ubuntu 16.04