### PR TITLE
Add assumptions on action space and valid actions to env and mdp

### DIFF
--- a/agents.py
+++ b/agents.py
@@ -60,10 +60,10 @@ class RandomAgent(Mind):
         """Initialize random agent.
 
         Args:
-            action_space (np.ndarray): Discrete or continuous hrl.Environment action_space. 
+            action_space (int): Number of possible actions. 
         """
 
-        self.action_space = action_space
+        self.action_space = np.arange(action_space)
 
     def plan(self, state, train_mode, debug_mode):
         """Ignores all arguments and return random action from action space.
@@ -72,14 +72,9 @@ class RandomAgent(Mind):
             ...see `hrl.Environment::valid_actions` docstring...
 
         Returns:
-            int or np.ndarray: Random action from action space.
+            np.ndarray: One hot action vector.
         """
 
-        if len(self.action_space.shape) == 1:
-            one_hot = np.zeros_like(self.action_space)
-            one_hot[np.random.choice(self.action_space)] = 1
-            return one_hot
-        elif len(self.action_space.shape) == 2:
-            return np.random.uniform(self.action_space.T[0], self.action_space.T[1])
-        else:
-            raise ValueError("Invalid action space!")
+        one_hot = np.zeros_like(self.action_space)
+        one_hot[np.random.choice(self.action_space)] = 1
+        return one_hot

--- a/environments.py
+++ b/environments.py
@@ -6,7 +6,12 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 
 
 class Environment(metaclass=ABCMeta):
-    """Abstract class for environments."""
+    """Abstract class for environments.
+
+    Note:
+        Currently only discrete action space is supported! Actions have to be numbers in range
+        [0, `self.action_space`).
+    """
 
     @abstractmethod
     def render(self):
@@ -49,7 +54,7 @@ class Environment(metaclass=ABCMeta):
         """Get action space definition.
 
         Returns:
-            object: Action space representation depends on environment.
+            int: Number of actions.
         """
 
         pass
@@ -79,14 +84,19 @@ class Environment(metaclass=ABCMeta):
         """Get currently available actions.
 
         Returns:
-            object: Available actions representation depends on environment.
+            np.ndarray: Array with enumerated valid actions for current state.
         """
 
         pass
 
 
 class MDP(metaclass=ABCMeta):
-    """Interface for MDP, describes state and action spaces and their dynamics."""
+    """Interface for MDP, describes state and action spaces and their dynamics.
+
+    Note:
+        Currently only discrete action space is supported! Actions have to be numbers in range
+        [0, `self.action_space`).
+    """
 
     @abstractmethod
     def transition(self, state, action):
@@ -121,7 +131,7 @@ class MDP(metaclass=ABCMeta):
             state (object): MDP's state.
 
         Returns:
-            object: Available actions representation depends on environment.
+            np.ndarray: Array with enumerated valid actions for given state.
         """
 
         pass
@@ -144,7 +154,7 @@ class MDP(metaclass=ABCMeta):
         """Get action space definition.
 
         Returns:
-            object: Action space representation depends on model.
+            int: Number of actions.
         """
 
         pass


### PR DESCRIPTION
Te założenia są wykorzystywane w `core.py`, samplach i AlphaZero oraz WorldModels. Teraz dopisałem je do interfejsów.