### PR TITLE
Require specific version of scipy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # See: https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
+scipy == 1.2.1
 gym[atari] >= 0.9.7
 numpy >= 1.14.5
 pytest >= 3.3.2


### PR DESCRIPTION
It is needed for gym sokoban which uses deprecated API from scipy